### PR TITLE
Bump alg_id after recent changes.

### DIFF
--- a/src/signature/eddsa.rs
+++ b/src/signature/eddsa.rs
@@ -4,7 +4,7 @@ use hmac_sha512::Hash;
 use std::u32;
 
 const CONTEXT: &[u8] = b"WasmSignature";
-pub const ALG_ID: u32 = 0x0000_0001;
+pub const ALG_ID: u32 = 0x0000_0002;
 
 pub struct EdDSA;
 


### PR DESCRIPTION
Commit 0ba684f8 introduced backwards incompatible changes:

1. The signature algorithm is no longer Ed25519ph (RFC8032).

2. Secret Keys now include their Public Key counterparts, so
   previously generated Secret Keys no longer work.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>